### PR TITLE
refactor(MessageManager): merge `search` parameters

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -178,7 +178,7 @@ class MessageManager extends CachedManager {
    *   console.log(`I found: **${hit}**, total results: ${res.totalResults}`);
    * }).catch(console.error);
    */
-  async search(query = {}, cache = true) {
+  async search({ cache = true, ...query } = {}) {
     const data = await this.client.api.channels[this.channel.id].messages.search.get({ query });
     const messages = new Collection();
     for (const message of data.messages.flat()) messages.set(message.id, this._add(message, cache));

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -181,6 +181,9 @@ class MessageManager extends CachedManager {
   async search({ cache = true, ...query } = {}) {
     const data = await this.client.api.channels[this.channel.id].messages.search.get({ query });
     const messages = new Collection();
+
+    if (query.sortOrder === 'asc') data.messages.reverse();
+
     for (const message of data.messages.flat()) messages.set(message.id, this._add(message, cache));
     return messages;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2554,7 +2554,7 @@ export class MessageManager extends CachedManager<Snowflake, Message, MessageRes
   public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;
   public react(message: MessageResolvable, emoji: EmojiIdentifierResolvable): Promise<void>;
   public pin(message: MessageResolvable): Promise<void>;
-  public search(query: MessageSearchOptions, cache?: boolean): Promise<Collection<Snowflake, Message>>;
+  public search(query?: MessageSearchOptions): Promise<Collection<Snowflake, Message>>;
   public unpin(message: MessageResolvable): Promise<void>;
 }
 
@@ -3044,7 +3044,7 @@ export interface BaseFetchOptions {
   force?: boolean;
 }
 
-export interface MessageSearchOptions {
+export interface MessageSearchOptions extends Omit<BaseFetchOptions, 'force'> {
 	content?: string;
 	maxID?: Snowflake;
 	minID?: Snowflake;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2554,7 +2554,7 @@ export class MessageManager extends CachedManager<Snowflake, Message, MessageRes
   public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;
   public react(message: MessageResolvable, emoji: EmojiIdentifierResolvable): Promise<void>;
   public pin(message: MessageResolvable): Promise<void>;
-  public search(query?: MessageSearchOptions): Promise<Collection<Snowflake, Message>>;
+  public search(options?: MessageSearchOptions): Promise<Collection<Snowflake, Message>>;
   public unpin(message: MessageResolvable): Promise<void>;
 }
 


### PR DESCRIPTION
This PR combines the cache into the query option